### PR TITLE
Align driver dashboard styling with nurse layout

### DIFF
--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.html
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.html
@@ -5,7 +5,7 @@
     <!-- Sidebar -->
     <aside class="sidebar">
       <div class="sidebar-top d-flex align-items-center justify-content-between px-3 py-2">
-        <span class="sidebar-title fw-semibold text-truncate">Nurse Panel</span>
+        <span class="sidebar-title fw-semibold text-truncate">Driver Panel</span>
       </div>
 
       <nav class="nav flex-column px-2">

--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.scss
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.scss
@@ -1,52 +1,71 @@
-/* features/driver-dashboard/driver-dashboard.component.scss */
-.dashboard {
-  min-height: 100vh;
-  background: #f6f8f9;
+/* Scoped dashboard theme for driver */
+:host {
+  --sidebar-w: 260px;
+  --sidebar-w-collapsed: 78px;
+  --sidebar-bg: #1f3b3b;
+  --sidebar-fg: #e2e8f0;
+  --sidebar-muted: #94a3b8;
+  --sidebar-active: #0ea5e9;
+  --content-bg: #f8fafc;
 }
 
+.dashboard-shell {
+  min-height: 100dvh;
+  background: var(--content-bg);
+}
+
+.dashboard-body {
+  min-height: calc(100dvh - 72px);
+}
+
+/* Sidebar */
 .sidebar {
+  width: var(--sidebar-w);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+  border-inline-end: 1px solid rgba(255,255,255,0.06);
+  transition: width .25s ease;
   position: sticky;
   top: 0;
-  height: 100vh;
-  width: 270px;
-  background: #1f3b3b;
-  color: #fff;
-  padding: 1rem;
-  transition: width .2s ease-in-out;
-  box-shadow: 0 4px 22px rgba(0,0,0,.08);
-  z-index: 100;
-
-  &.collapsed {
-    width: 64px;
-    .nav-link {
-      text-align: center;
-      i { margin-inline-end: 0 !important; }
-      span { display: none; }
-    }
-    .logo { display: none; }
-  }
-
-  .sidebar-header .logo {
-    font-weight: 700;
-    letter-spacing: .5px;
-  }
-
-  .nav-link {
-    color: #e9f3f3;
-    padding: .65rem .75rem;
-    border-radius: .75rem;
-    margin-bottom: .25rem;
-    transition: background .15s ease-in-out;
-    display: flex;
-    align-items: center;
-    i { margin-inline-end: .5rem; font-size: 1.1rem; }
-    &.active, &:hover {
-      background: #2a4c4c;
-      color: #fff;
-    }
-  }
+  height: calc(100dvh - 72px);
 }
 
-.content {
-  padding-inline: 1rem;
+.sidebar.collapsed { width: var(--sidebar-w-collapsed); }
+
+.sidebar-top {
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  .sidebar-title { color: var(--sidebar-fg); }
+  .btn { color: var(--sidebar-fg); border-color: rgba(255,255,255,0.2); }
+  .btn:hover { background: rgba(255,255,255,0.08); }
+}
+
+.nav-link {
+  color: var(--sidebar-fg);
+  border-radius: .5rem;
+  padding: .65rem .75rem;
+  margin: .25rem .25rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.nav-link:hover { background: rgba(255,255,255,0.06); color: #fff; }
+
+.nav-link .bi { font-size: 1.1rem; color: var(--sidebar-muted); }
+.nav-link.active {
+  color: #fff;
+  background: rgba(14,165,233,0.15);
+  border: 1px solid rgba(14,165,233,0.35);
+}
+.nav-link.active .bi { color: var(--sidebar-active); }
+.label { font-size: .95rem; }
+
+/* Main content */
+.content { overflow: hidden; }
+.content-inner {
+  padding: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 991.98px) {
+  .sidebar { position: fixed; z-index: 1040; height: 100dvh; }
+  .content-inner { padding-top: 1rem; }
 }

--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.ts
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.ts
@@ -1,38 +1,30 @@
-import { Component, inject, signal } from '@angular/core';
-import { DriverHeader } from "../../components/driver-header/driver-header";
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { DriverHeader } from '../../components/driver-header/driver-header';
 
-import { ToastrService } from 'ngx-toastr';
-import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { NgClass } from '@angular/common';
 type MenuItem = { path: string; label: string; icon: string; exact?: boolean };
 
 @Component({
   selector: 'app-driver-layout',
-  imports: [DriverHeader,NgClass , RouterLink, RouterLinkActive, RouterOutlet],
+  standalone: true,
+  imports: [CommonModule, DriverHeader, RouterLink, RouterLinkActive, RouterOutlet],
   templateUrl: './driver-layout.html',
-  styleUrl: './driver-layout.scss'
+  styleUrls: ['./driver-layout.scss']
 })
-export class DriverLayout {
-  
-    private readonly router = inject(Router); // OPTIONAL: for programmatic nav
-  
-    // UPDATED: sidebar menu (Bootstrap Icons)
-    menu: MenuItem[] = [
-      { path: 'pending-requests',  label: 'Pending Approval', icon: 'bi-clock-history', exact: true },
-      { path: 'approved', label: 'Approved',         icon: 'bi-check2-circle' },
-      { path: 'schedule', label: 'Your Schedule',    icon: 'bi-calendar3' },
-      { path: 'withdrawal', label: 'Your withdrawal',    icon: 'bi-calendar3' }
-  
-      // You can show patient details from a row click: /nurse/patient/:id
-    ];
-  
-    ngOnInit(): void {
-      // The shell no longer fetches requests; each page loads its own data. // UPDATED
-    }
-  
-    // OPTIONAL: If you want to navigate to the patient page from anywhere in the shell
-    goToPatient(id?: number) {
-      if (id) this.router.navigate(['/nurse/patient', id]);
-    }
+export class DriverLayout implements OnInit {
+
+  // Sidebar menu (Bootstrap Icons)
+  menu: MenuItem[] = [
+    { path: 'pending-requests',  label: 'Pending Approval', icon: 'bi-clock-history', exact: true },
+    { path: 'approved', label: 'Approved',         icon: 'bi-check2-circle' },
+    { path: 'schedule', label: 'Your Schedule',    icon: 'bi-calendar3' },
+    { path: 'withdrawal', label: 'Your withdrawal',    icon: 'bi-calendar3' }
+    // Additional links can be added here
+  ];
+
+  ngOnInit(): void {
+    // The shell no longer fetches requests; each page loads its own data.
   }
+}
   


### PR DESCRIPTION
## Summary
- Rename driver sidebar heading to "Driver Panel" for clarity
- Convert driver layout to standalone component using `CommonModule` and shared routing directives
- Rework driver dashboard SCSS to mirror nurse layout styling with driver color theme

## Testing
- `npm test` *(fails: Module has no exported member in various spec files)*

------
https://chatgpt.com/codex/tasks/task_e_689cf6ec6ea08329b86b3c44806ac2cf