### PR TITLE
Align driver dashboard styling with nurse layout

### DIFF
--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.html
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.html
@@ -5,7 +5,7 @@
     <!-- Sidebar -->
     <aside class="sidebar">
       <div class="sidebar-top d-flex align-items-center justify-content-between px-3 py-2">
-        <span class="sidebar-title fw-semibold text-truncate">Nurse Panel</span>
+        <span class="sidebar-title fw-semibold text-truncate">Driver Panel</span>
       </div>
 
       <nav class="nav flex-column px-2">

--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.scss
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.scss
@@ -1,52 +1,71 @@
-/* features/driver-dashboard/driver-dashboard.component.scss */
-.dashboard {
-  min-height: 100vh;
-  background: #f6f8f9;
+/* Scoped dashboard theme for driver */
+:host {
+  --sidebar-w: 260px;
+  --sidebar-w-collapsed: 78px;
+  --sidebar-bg: #1f3b3b;
+  --sidebar-fg: #e2e8f0;
+  --sidebar-muted: #94a3b8;
+  --sidebar-active: #0ea5e9;
+  --content-bg: #f8fafc;
 }
 
+.dashboard-shell {
+  min-height: 100dvh;
+  background: var(--content-bg);
+}
+
+.dashboard-body {
+  min-height: calc(100dvh - 72px);
+}
+
+/* Sidebar */
 .sidebar {
+  width: var(--sidebar-w);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+  border-inline-end: 1px solid rgba(255,255,255,0.06);
+  transition: width .25s ease;
   position: sticky;
   top: 0;
-  height: 100vh;
-  width: 270px;
-  background: #1f3b3b;
-  color: #fff;
-  padding: 1rem;
-  transition: width .2s ease-in-out;
-  box-shadow: 0 4px 22px rgba(0,0,0,.08);
-  z-index: 100;
-
-  &.collapsed {
-    width: 64px;
-    .nav-link {
-      text-align: center;
-      i { margin-inline-end: 0 !important; }
-      span { display: none; }
-    }
-    .logo { display: none; }
-  }
-
-  .sidebar-header .logo {
-    font-weight: 700;
-    letter-spacing: .5px;
-  }
-
-  .nav-link {
-    color: #e9f3f3;
-    padding: .65rem .75rem;
-    border-radius: .75rem;
-    margin-bottom: .25rem;
-    transition: background .15s ease-in-out;
-    display: flex;
-    align-items: center;
-    i { margin-inline-end: .5rem; font-size: 1.1rem; }
-    &.active, &:hover {
-      background: #2a4c4c;
-      color: #fff;
-    }
-  }
+  height: calc(100dvh - 72px);
 }
 
-.content {
-  padding-inline: 1rem;
+.sidebar.collapsed { width: var(--sidebar-w-collapsed); }
+
+.sidebar-top {
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  .sidebar-title { color: var(--sidebar-fg); }
+  .btn { color: var(--sidebar-fg); border-color: rgba(255,255,255,0.2); }
+  .btn:hover { background: rgba(255,255,255,0.08); }
+}
+
+.nav-link {
+  color: var(--sidebar-fg);
+  border-radius: .5rem;
+  padding: .65rem .75rem;
+  margin: .25rem .25rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.nav-link:hover { background: rgba(255,255,255,0.06); color: #fff; }
+
+.nav-link .bi { font-size: 1.1rem; color: var(--sidebar-muted); }
+.nav-link.active {
+  color: #fff;
+  background: rgba(14,165,233,0.15);
+  border: 1px solid rgba(14,165,233,0.35);
+}
+.nav-link.active .bi { color: var(--sidebar-active); }
+.label { font-size: .95rem; }
+
+/* Main content */
+.content { overflow: hidden; }
+.content-inner {
+  padding: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 991.98px) {
+  .sidebar { position: fixed; z-index: 1040; height: 100dvh; }
+  .content-inner { padding-top: 1rem; }
 }

--- a/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.ts
+++ b/src/app/Layout/Driver/DriverLayout/driver-layout/driver-layout.ts
@@ -1,38 +1,30 @@
-import { Component, inject, signal } from '@angular/core';
-import { DriverHeader } from "../../components/driver-header/driver-header";
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { DriverHeader } from '../../components/driver-header/driver-header';
 
-import { ToastrService } from 'ngx-toastr';
-import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { NgClass } from '@angular/common';
 type MenuItem = { path: string; label: string; icon: string; exact?: boolean };
 
 @Component({
   selector: 'app-driver-layout',
-  imports: [DriverHeader,NgClass , RouterLink, RouterLinkActive, RouterOutlet],
+  standalone: true,
+  imports: [CommonModule, DriverHeader, RouterLink, RouterLinkActive, RouterOutlet],
   templateUrl: './driver-layout.html',
-  styleUrl: './driver-layout.scss'
+  styleUrls: ['./driver-layout.scss']
 })
-export class DriverLayout {
-  
-    private readonly router = inject(Router); // OPTIONAL: for programmatic nav
-  
-    // UPDATED: sidebar menu (Bootstrap Icons)
-    menu: MenuItem[] = [
-      { path: 'pending-requests',  label: 'Pending Approval', icon: 'bi-clock-history', exact: true },
-      { path: 'approved', label: 'Approved',         icon: 'bi-check2-circle' },
-      { path: 'schedule', label: 'Your Schedule',    icon: 'bi-calendar3' },
-      { path: 'withdrawal', label: 'Your withdrawal',    icon: 'bi-calendar3' }
-  
-      // You can show patient details from a row click: /nurse/patient/:id
-    ];
-  
-    ngOnInit(): void {
-      // The shell no longer fetches requests; each page loads its own data. // UPDATED
-    }
-  
-    // OPTIONAL: If you want to navigate to the patient page from anywhere in the shell
-    goToPatient(id?: number) {
-      if (id) this.router.navigate(['/nurse/patient', id]);
-    }
+export class DriverLayout implements OnInit {
+
+  // Sidebar menu (Bootstrap Icons)
+  menu: MenuItem[] = [
+    { path: 'pending-requests',  label: 'Pending Approval', icon: 'bi-clock-history', exact: true },
+    { path: 'approved', label: 'Approved',         icon: 'bi-check2-circle' },
+    { path: 'schedule', label: 'Your Schedule',    icon: 'bi-calendar3' },
+    { path: 'withdrawal', label: 'Your withdrawal',    icon: 'bi-calendar3' }
+    // Additional links can be added here
+  ];
+
+  ngOnInit(): void {
+    // The shell no longer fetches requests; each page loads its own data.
   }
+}
   

--- a/src/app/Layout/Driver/components/driver-approved-requests/driver-approved-requests.ts
+++ b/src/app/Layout/Driver/components/driver-approved-requests/driver-approved-requests.ts
@@ -9,6 +9,7 @@ import { CommonModule, DatePipe, NgClass } from '@angular/common';
 
 @Component({
   selector: 'app-driver-approved-requests',
+  standalone: true,
   imports: [FormsModule, ReactiveFormsModule, NgClass, DatePipe, CommonModule],
   templateUrl: './driver-approved-requests.html',
   styleUrl: './driver-approved-requests.scss'

--- a/src/app/Layout/Driver/components/pending-requests/pending-requests.spec.ts
+++ b/src/app/Layout/Driver/components/pending-requests/pending-requests.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { PendingRequests } from './pending-requests';
+import { DriverPendingRequests } from './pending-requests';
 
-describe('PendingRequests', () => {
-  let component: PendingRequests;
-  let fixture: ComponentFixture<PendingRequests>;
+describe('DriverPendingRequests', () => {
+  let component: DriverPendingRequests;
+  let fixture: ComponentFixture<DriverPendingRequests>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PendingRequests]
+      imports: [DriverPendingRequests]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(PendingRequests);
+    fixture = TestBed.createComponent(DriverPendingRequests);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/Layout/Driver/components/pending-requests/pending-requests.ts
+++ b/src/app/Layout/Driver/components/pending-requests/pending-requests.ts
@@ -7,6 +7,7 @@ import { RequestService } from '../../../../Core/Services/RequestService/request
 
 @Component({
   selector: 'app-pending-requests',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './pending-requests.html',
   styleUrl: './pending-requests.scss'

--- a/src/app/Layout/Driver/components/schedule/schedule.spec.ts
+++ b/src/app/Layout/Driver/components/schedule/schedule.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Schedule } from './schedule';
+import { DriverSchedule } from './schedule';
 
-describe('Schedule', () => {
-  let component: Schedule;
-  let fixture: ComponentFixture<Schedule>;
+describe('DriverSchedule', () => {
+  let component: DriverSchedule;
+  let fixture: ComponentFixture<DriverSchedule>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Schedule]
+      imports: [DriverSchedule]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Schedule);
+    fixture = TestBed.createComponent(DriverSchedule);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/Layout/Driver/components/schedule/schedule.ts
+++ b/src/app/Layout/Driver/components/schedule/schedule.ts
@@ -5,6 +5,7 @@ import { TripStatus } from '../../../../Core/interface/Trip/itrip';
 
 @Component({
   selector: 'app-schedule',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './schedule.html',
   styleUrl: './schedule.scss'

--- a/src/app/Layout/Driver/components/trip-details/trip-details.ts
+++ b/src/app/Layout/Driver/components/trip-details/trip-details.ts
@@ -3,6 +3,7 @@ import { ITripData } from '../../../../Core/interface/itrip-data';
 
 @Component({
   selector: 'app-trip-details',
+  standalone: true,
   imports: [],
   templateUrl: './trip-details.html',
   styleUrl: './trip-details.scss'

--- a/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.html
+++ b/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.html
@@ -1,0 +1,132 @@
+<div class="card shadow-sm animate__animated animate__fadeIn">
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <div class="d-flex align-items-center gap-2">
+      <i class="bi bi-cash-coin"></i>
+      <strong>Withdrawal Requests</strong>
+    </div>
+
+    <div class="d-flex align-items-center gap-2">
+      <button class="btn btn-sm btn-outline-primary" (click)="loadRequests()">
+        <i class="bi bi-arrow-clockwise me-1"></i> Refresh
+      </button>
+    </div>
+  </div>
+
+  <div class="card-body">
+    <!-- Tabs -->
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      @for (t of tabs; track t.key) {
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            [class.active]="activeTab === t.key"
+            type="button"
+            (click)="activeTab = t.key"
+            role="tab">
+            {{ t.label }}
+            <span class="badge bg-secondary ms-2">{{ count(t.key) }}</span>
+          </button>
+        </li>
+      }
+    </ul>
+
+    @if (loading) {
+      <div class="alert alert-info d-flex align-items-center gap-2">
+        <i class="bi bi-arrow-repeat"></i> Loading...
+      </div>
+    }
+
+    @if (error) {
+      <div class="alert alert-danger d-flex align-items-center gap-2">
+        <i class="bi bi-exclamation-triangle"></i> {{ error }}
+      </div>
+    }
+
+    @if (!loading && !error && getFiltered().length === 0) {
+      <div class="text-center py-5">
+        <i class="bi bi-inbox fs-1 text-muted d-block mb-2"></i>
+        <div class="text-muted">No {{ getActiveTabLabel() || 'matching' }} requests</div>
+      </div>
+    } @else {
+      <div class="table-responsive">
+        <table class="table align-middle table-hover"> <!-- UPDATED: hover -->
+          <thead class="table-light">
+            <tr>
+              <!-- <th>#</th> -->
+              <!-- <th>User</th> -->
+              <th>Amount</th>
+              <th>Requested</th>
+              <th>Status</th>
+              <th>Processed</th>
+              <!-- <th>Admin</th> -->
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (r of getFiltered(); track $index) { <!-- UPDATED: trackById -->
+              <tr class="animate__animated animate__fadeInUp">
+                <!-- <td class="fw-semibold">#{{ r.id }}</td>
+                <td>
+                  <div class="d-flex flex-column">
+                    <span class="fw-medium">{{ r.userName }}</span>
+                    <small class="text-muted">{{ r.userType }}</small>
+                    <small class="text-muted">{{ r.userId }}</small>
+                  </div>
+                </td> -->
+
+                <!-- UPDATED: use number directly with currency pipe -->
+                <td class="fw-bold">{{ r.amount | currency:'EGP':'symbol' }}</td>
+
+                <!-- UPDATED: no .toString() needed -->
+                <td>
+                  <div class="small text-muted">
+                    <i class="bi bi-calendar3 me-1"></i>
+                    {{ r.requestDate | date:'medium' }}
+                  </div>
+                </td>
+
+                <td>
+                  <span class="{{ getStatusBadgeClass(r.status) }}">
+                    <i class="bi me-1" [ngClass]="getStatusIcon(r.status)"></i>
+                    {{ getStatusText(r.status) }}
+                  </span>
+                </td>
+
+                <td>
+                  @if (r.processedDate) {
+                    <div class="small text-muted">
+                      <i class="bi bi-calendar-check me-1"></i>
+                      {{ r.processedDate | date:'medium' }}
+                    </div>
+                  } @else {
+                    <span class="badge bg-light text-dark">—</span>
+                  }
+                </td>
+
+                <!-- <td>
+                  @if (r.processedByAdminName) {
+                    <div class="small">
+                      <i class="bi bi-person-check me-1"></i>{{ r.processedByAdminName }}
+                    </div>
+                  } @else {
+                    <span class="badge bg-light text-dark">—</span>
+                  }
+                </td> -->
+
+                <td>
+                  @if (r.adminNotes) {
+                    <span class="text-truncate d-inline-block" style="max-width: 220px;" [title]="r.adminNotes">
+                      {{ r.adminNotes }}
+                    </span>
+                  } @else {
+                    <span class="text-muted">—</span>
+                  }
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.scss
+++ b/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.scss
@@ -1,0 +1,21 @@
+.card { border-radius: .75rem; }
+
+.nav-tabs .nav-link {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.table td, .table th { vertical-align: middle; }
+
+.badge i { font-size: .95rem; }
+
+/* Subtle zebra striping & hover already added via table-hover */
+.table > :not(caption) > * > * { padding: .75rem .75rem; }
+
+/* Optional: compact spacing on small screens */
+@media (max-width: 576px) {
+  .card-body { padding: .75rem; }
+  .nav-tabs .nav-link { padding: .5rem .75rem; }
+}

--- a/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.spec.ts
+++ b/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { DriverTripDetails } from './trip-details';
+import { WithdrawalDriver } from './withdrawal-driver';
 
-describe('DriverTripDetails', () => {
-  let component: DriverTripDetails;
-  let fixture: ComponentFixture<DriverTripDetails>;
+describe('WithdrawalDriver', () => {
+  let component: WithdrawalDriver;
+  let fixture: ComponentFixture<WithdrawalDriver>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DriverTripDetails]
+      imports: [WithdrawalDriver]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(DriverTripDetails);
+    fixture = TestBed.createComponent(WithdrawalDriver);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.ts
+++ b/src/app/Layout/Driver/components/withdrawal-driver/withdrawal-driver.ts
@@ -1,0 +1,114 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+import { WithdrawalUserRequests, WithdrawalStatus } from '../../../../Core/interface/Admin/profit';
+import { ProfitService } from '../../../../Core/Services/AdminServices/profit.service';
+import { GenerialResponse } from '../../../../Core/interface/GenerialResponse/GenerialResponse';
+import { CurrencyPipe, DatePipe, NgClass } from '@angular/common';
+
+type TabKey = 'all' | WithdrawalStatus;
+
+@Component({
+  selector: 'app-withdrawal-driver',
+  standalone: true,
+  imports: [CurrencyPipe, DatePipe, NgClass],
+  templateUrl: './withdrawal-driver.html',
+  styleUrl: './withdrawal-driver.scss'
+})
+export class WithdrawalDriver implements OnInit {
+  private readonly toastr = inject(ToastrService);
+  private readonly profitService = inject(ProfitService); // UPDATED: lowerCamelCase
+
+  requests: WithdrawalUserRequests[] = [];
+  loading = false;
+  error = '';
+
+  readonly Status = WithdrawalStatus;
+
+  // UPDATED: correct label for Completed, and strong typing
+  readonly tabs: ReadonlyArray<{ key: TabKey; label: string }> = [
+    { key: 'all',                    label: 'All' },
+    { key: WithdrawalStatus.Pending, label: 'Pending' },
+    { key: WithdrawalStatus.Approved,label: 'Approved' },
+    { key: WithdrawalStatus.Rejected,label: 'Rejected' },
+    { key: WithdrawalStatus.Completed,label: 'Completed' }
+  ];
+
+  activeTab: TabKey = 'all';
+
+  ngOnInit(): void {
+    this.loadRequests();
+  }
+
+  // API
+  loadRequests(): void {
+    this.loading = true;
+    this.error = '';
+    this.profitService.getUserRequests().subscribe({
+      next: (res: GenerialResponse<WithdrawalUserRequests[]>) => {
+        this.requests = res?.data ?? [];
+        if (res?.success) {
+          // this.toastr.success(res.message || 'Withdrawal requests loaded.', 'Success');
+        } else {
+          // this.toastr.warning(res?.message || 'Loaded with warnings.', 'Notice');
+        }
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = 'Failed to load withdrawal requests.';
+        // this.toastr.error(this.error, 'Error');
+        this.loading = false;
+        console.error(err);
+      }
+    });
+  }
+
+  // Filtering / counts
+  trackById = (_: number, r: WithdrawalUserRequests) => r.id; // UPDATED: use id, not $index
+
+  count(tab: TabKey): number {
+    return tab === 'all' ? this.requests.length : this.requests.filter(r => r.status === tab).length;
+  }
+
+  getFiltered(): WithdrawalUserRequests[] {
+    return this.activeTab === 'all' ? this.requests : this.requests.filter(r => r.status === this.activeTab);
+  }
+
+  // Status helpers (texts, badges, icons)
+  getStatusText(status: WithdrawalStatus): string {
+    switch (status) {
+      case WithdrawalStatus.Pending:   return 'Pending';
+      case WithdrawalStatus.Approved:  return 'Approved';
+      case WithdrawalStatus.Rejected:  return 'Rejected';
+      case WithdrawalStatus.Completed: return 'Completed';
+      default:                         return 'Unknown';
+    }
+  }
+
+  // UPDATED: softer, consistent badge palette
+  getStatusBadgeClass(status: WithdrawalStatus): string {
+    switch (status) {
+      case WithdrawalStatus.Pending:   return 'badge bg-warning-subtle text-warning-emphasis';
+      case WithdrawalStatus.Approved:  return 'badge bg-success-subtle text-success-emphasis';
+      case WithdrawalStatus.Rejected:  return 'badge bg-danger-subtle text-danger-emphasis';
+      case WithdrawalStatus.Completed: return 'badge bg-primary-subtle text-primary-emphasis';
+      default:                         return 'badge bg-light text-dark';
+    }
+  }
+
+  // UPDATED: nicer BI icons per status
+  getStatusIcon(status: WithdrawalStatus): string {
+    switch (status) {
+      case WithdrawalStatus.Pending:   return 'bi-hourglass-split';
+      case WithdrawalStatus.Approved:  return 'bi-patch-check-fill';
+      case WithdrawalStatus.Rejected:  return 'bi-x-octagon-fill';
+      case WithdrawalStatus.Completed: return 'bi-check-all';
+      default:                         return 'bi-question-circle';
+    }
+  }
+
+  // To avoid inline .find() in template
+  getActiveTabLabel(): string {
+    const t = this.tabs.find(tab => tab.key === this.activeTab);
+    return t ? t.label : '';
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,10 +10,6 @@ import { DriverLayout } from './Layout/Driver/DriverLayout/driver-layout/driver-
 import { ReservationFrom } from './Layout/reservation-from/reservation-from';
 import { BookingViewComponent } from './Layout/admin-layout/Components/AdminDashborad/Components/view-booking/view-booking';
 import { PatintLayout } from './Layout/patint-layout/patint-layout';
-import { DriverPendingRequests } from './Layout/Driver/components/pending-requests/pending-requests';
-import { DriverSchedule } from './Layout/Driver/components/schedule/schedule';
-import { DriverTripDetails } from './Layout/Driver/components/trip-details/trip-details';
-import { DriverApprovedRequests } from './Layout/Driver/components/driver-approved-requests/driver-approved-requests';
 
 export const routes: Routes = [
 
@@ -59,10 +55,11 @@ export const routes: Routes = [
                 component: DriverLayout,
                 children: [
                     { path: '', redirectTo: 'pending-requests', pathMatch: 'full' },
-                    { path: 'pending-requests', component: DriverPendingRequests },
-                    { path: 'approved', component: DriverApprovedRequests },
-                    { path: 'trip-details', component: DriverTripDetails },
-                    { path: 'schedule', component: DriverSchedule },
+                    { path: 'pending-requests', loadComponent: () => import('../app/Layout/Driver/components/pending-requests/pending-requests').then(m => m.DriverPendingRequests) },
+                    { path: 'approved', loadComponent: () => import('../app/Layout/Driver/components/driver-approved-requests/driver-approved-requests').then(m => m.DriverApprovedRequests) },
+                    { path: 'trip-details', loadComponent: () => import('../app/Layout/Driver/components/trip-details/trip-details').then(m => m.DriverTripDetails) },
+                    { path: 'schedule', loadComponent: () => import('../app/Layout/Driver/components/schedule/schedule').then(m => m.DriverSchedule) },
+                    { path: 'withdrawal', loadComponent: () => import('../app/Layout/Driver/components/withdrawal-driver/withdrawal-driver').then(m => m.WithdrawalDriver) },
                 ]
             },
 


### PR DESCRIPTION
## Summary
- Lazy load driver dashboard pages and match nurse navigation, adding a withdrawal route
- Convert driver pages to standalone components and create driver-specific withdrawal component

## Testing
- `npm test` *(fails: Module has no exported member and declaration errors in several spec files)*


------
https://chatgpt.com/codex/tasks/task_e_689cf6ec6ea08329b86b3c44806ac2cf