### PR TITLE
feat: add payment modal to trip page

### DIFF
--- a/src/app/Layout/patint-layout/Components/trip-page/trip-page.html
+++ b/src/app/Layout/patint-layout/Components/trip-page/trip-page.html
@@ -115,7 +115,7 @@
           <button class="btn btn-sm btn-primary me-2" (click)="startTrip(trip.tripId)" [disabled]="!canStart(trip)">
             Start
           </button>
-          <button class="btn btn-sm btn-success" (click)="completeTrip(trip.tripId)" [disabled]="!canComplete(trip)">
+          <button class="btn btn-sm btn-success" (click)="openPayment(trip)" [disabled]="!canComplete(trip)">
             Complete
           </button>
         </div>
@@ -176,7 +176,7 @@
 
         </div>
         <div class="actions mt-3">
-          <button class="btn btn-sm btn-success" (click)="completeTrip(trip.tripId)" [disabled]="!canComplete(trip)">
+          <button class="btn btn-sm btn-success" (click)="openPayment(trip)" [disabled]="!canComplete(trip)">
             Complete
           </button>
         </div>
@@ -248,5 +248,8 @@
     }
     }
   </div>
+  }
+  @if (showPayment) {
+    <app-payment [tripId]="paymentTripId!" [price]="paymentPrice!" (close)="handlePaymentClose($event)"></app-payment>
   }
 </div>

--- a/src/app/Layout/patint-layout/Components/trip-page/trip-page.ts
+++ b/src/app/Layout/patint-layout/Components/trip-page/trip-page.ts
@@ -6,11 +6,12 @@ import { ITrip, TripStatus } from '../../../../Core/interface/Trip/itrip';
 import { AuthService } from '../../../../Core/Services/AuthServices/auth-service';
 import { Environment } from '../../../../../environments/environment';
 import { TripTracker } from "../trip-tracker/trip-tracker";
+import { Payment } from '../../../../Shared/Components/payment/payment';
 
 @Component({
   selector: 'app-trip-page',
   standalone: true,
-  imports: [CommonModule, TripTracker],
+  imports: [CommonModule, TripTracker, Payment],
   templateUrl: './trip-page.html',
   styleUrls: ['./trip-page.scss']
 })
@@ -27,6 +28,10 @@ export class TripPage implements OnInit {
   loading = false;
   error = '';
   selectedTab: 'today' | 'upcoming' | 'completed' = 'today';
+
+  showPayment = false;
+  paymentTripId?: number;
+  paymentPrice?: number;
 
   ngOnInit(): void {
     this.loadPatientTrips();
@@ -109,17 +114,17 @@ export class TripPage implements OnInit {
     });
   }
 
-  completeTrip(tripId: number): void {
-    this.loading = true;
-    this.tripService.completeTrip(tripId).subscribe({
-      next: (res) => {
-        this.loadPatientTrips();
-      },
-      error: (err) => {
-        console.error('Error completing trip:', err);
-        this.loading = false;
-      }
-    });
+  openPayment(trip: ITrip): void {
+    this.paymentTripId = trip.tripId;
+    this.paymentPrice = trip.price;
+    this.showPayment = true;
+  }
+
+  handlePaymentClose(success: boolean): void {
+    this.showPayment = false;
+    if (success) {
+      this.loadPatientTrips();
+    }
   }
 
   /** UI helpers */

--- a/src/app/Shared/Components/payment/payment.html
+++ b/src/app/Shared/Components/payment/payment.html
@@ -1,0 +1,12 @@
+<div class="modal-backdrop"></div>
+<div class="modal-dialog">
+  <div class="modal-content p-4">
+    <h5 class="modal-title mb-3">Payment</h5>
+    <p>Trip ID: {{ tripId }}</p>
+    <p>Amount: {{ price | currency:'EGP':true }}</p>
+    <div class="d-flex gap-2 mt-3">
+      <button class="btn btn-primary" (click)="payNow()">Pay Now</button>
+      <button class="btn btn-secondary" (click)="cancel()">Close</button>
+    </div>
+  </div>
+</div>

--- a/src/app/Shared/Components/payment/payment.scss
+++ b/src/app/Shared/Components/payment/payment.scss
@@ -1,0 +1,17 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1040;
+}
+
+.modal-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1050;
+}

--- a/src/app/Shared/Components/payment/payment.ts
+++ b/src/app/Shared/Components/payment/payment.ts
@@ -1,0 +1,33 @@
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TripService } from '../../../Core/Services/TripService/trip';
+
+@Component({
+  selector: 'app-payment',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './payment.html',
+  styleUrls: ['./payment.scss']
+})
+export class Payment {
+  @Input() tripId!: number;
+  @Input() price!: number;
+  @Output() close = new EventEmitter<boolean>();
+
+  private readonly tripService = inject(TripService);
+
+  payNow(): void {
+    if (!this.tripId) {
+      this.close.emit(false);
+      return;
+    }
+    this.tripService.completeTrip(this.tripId).subscribe({
+      next: () => this.close.emit(true),
+      error: () => this.close.emit(false)
+    });
+  }
+
+  cancel(): void {
+    this.close.emit(false);
+  }
+}


### PR DESCRIPTION
## Summary
- move payment modal into Shared components for reuse
- load shared payment modal from trip page when completing trips

## Testing
- `npm test` *(fails: Module has no exported member in several spec files)*

------
https://chatgpt.com/codex/tasks/task_e_68a365f897d48329a29aa5f4ad3d5870