### PR TITLE
feat: add payment modal for completing trips

### DIFF
--- a/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.html
+++ b/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.html
@@ -1,0 +1,15 @@
+<div class="modal-backdrop fade show" (click)="closeModal()"></div>
+<div class="modal fade show d-block" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Payment for Trip #{{ tripId }}</h5>
+        <button type="button" class="btn-close" (click)="closeModal()" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <p class="mb-3">Amount due: {{ price | currency:'EGP':true }}</p>
+        <button type="button" class="btn btn-success" (click)="payNow()">Pay Now</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.scss
+++ b/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.scss
@@ -1,0 +1,22 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1040;
+}
+
+.modal-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1050;
+}
+
+.modal-content {
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.ts
+++ b/src/app/Layout/patint-layout/Components/payment-modal/payment-modal.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-payment-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './payment-modal.html',
+  styleUrls: ['./payment-modal.scss'],
+})
+export class PaymentModalComponent {
+  @Input() tripId!: number;
+  @Input() price!: number;
+
+  @Output() close = new EventEmitter<void>();
+  @Output() pay = new EventEmitter<void>();
+
+  closeModal(): void {
+    this.close.emit();
+  }
+
+  payNow(): void {
+    this.pay.emit();
+  }
+}
+

--- a/src/app/Layout/patint-layout/Components/trip-page/trip-page.html
+++ b/src/app/Layout/patint-layout/Components/trip-page/trip-page.html
@@ -115,7 +115,7 @@
           <button class="btn btn-sm btn-primary me-2" (click)="startTrip(trip.tripId)" [disabled]="!canStart(trip)">
             Start
           </button>
-          <button class="btn btn-sm btn-success" (click)="completeTrip(trip.tripId)" [disabled]="!canComplete(trip)">
+          <button class="btn btn-sm btn-success" (click)="openPaymentModal(trip)" [disabled]="!canComplete(trip)">
             Complete
           </button>
         </div>
@@ -176,7 +176,7 @@
 
         </div>
         <div class="actions mt-3">
-          <button class="btn btn-sm btn-success" (click)="completeTrip(trip.tripId)" [disabled]="!canComplete(trip)">
+          <button class="btn btn-sm btn-success" (click)="openPaymentModal(trip)" [disabled]="!canComplete(trip)">
             Complete
           </button>
         </div>
@@ -250,3 +250,12 @@
   </div>
   }
 </div>
+
+  @if (isPaymentVisible && paymentTripId !== null && paymentPrice !== null) {
+    <app-payment-modal
+      [tripId]="paymentTripId!"
+      [price]="paymentPrice!"
+      (close)="closePaymentModal()"
+      (pay)="completeTrip(paymentTripId!)">
+    </app-payment-modal>
+  }

--- a/src/app/Layout/patint-layout/Components/trip-page/trip-page.ts
+++ b/src/app/Layout/patint-layout/Components/trip-page/trip-page.ts
@@ -6,11 +6,12 @@ import { ITrip, TripStatus } from '../../../../Core/interface/Trip/itrip';
 import { AuthService } from '../../../../Core/Services/AuthServices/auth-service';
 import { Environment } from '../../../../../environments/environment';
 import { TripTracker } from "../trip-tracker/trip-tracker";
+import { PaymentModalComponent } from '../payment-modal/payment-modal';
 
 @Component({
   selector: 'app-trip-page',
   standalone: true,
-  imports: [CommonModule, TripTracker],
+  imports: [CommonModule, TripTracker, PaymentModalComponent],
   templateUrl: './trip-page.html',
   styleUrls: ['./trip-page.scss']
 })
@@ -27,6 +28,11 @@ export class TripPage implements OnInit {
   loading = false;
   error = '';
   selectedTab: 'today' | 'upcoming' | 'completed' = 'today';
+
+  // Payment modal state
+  isPaymentVisible = false;
+  paymentTripId: number | null = null;
+  paymentPrice: number | null = null;
 
   ngOnInit(): void {
     this.loadPatientTrips();
@@ -109,11 +115,24 @@ export class TripPage implements OnInit {
     });
   }
 
+  openPaymentModal(trip: ITrip): void {
+    this.paymentTripId = trip.tripId;
+    this.paymentPrice = trip.price;
+    this.isPaymentVisible = true;
+  }
+
+  closePaymentModal(): void {
+    this.isPaymentVisible = false;
+    this.paymentTripId = null;
+    this.paymentPrice = null;
+  }
+
   completeTrip(tripId: number): void {
     this.loading = true;
     this.tripService.completeTrip(tripId).subscribe({
-      next: (res) => {
+      next: () => {
         this.loadPatientTrips();
+        this.closePaymentModal();
       },
       error: (err) => {
         console.error('Error completing trip:', err);
@@ -152,7 +171,6 @@ export class TripPage implements OnInit {
   }
 
   canComplete(t: ITrip): boolean {
-    debugger
     return t.tripStatus === TripStatus.Ongoing;
   }
 


### PR DESCRIPTION
## Summary
- add standalone payment modal to collect trip payment
- open payment modal from trip page and complete trip on payment
- wire modal to send trip id and price
- use Angular control flow syntax for payment modal display

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run build` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a36d6556688329a01631afdb56d9ea